### PR TITLE
fix(route): add prefix /api for routes

### DIFF
--- a/src/internal/core/core.ts
+++ b/src/internal/core/core.ts
@@ -19,9 +19,9 @@ class Core {
 
     private loadHttp(usecase: Usecase) {
         const handler = new Handler(usecase, this.logger)
-        this.http.app.get('/v1/banners', handler.Banner())
-        this.http.app.get('/v1/activities', handler.Activity())
-        this.http.app.get('/v1/activities/:id', handler.ActivityByID())
+        this.http.app.get('api/v1/banners', handler.Banner())
+        this.http.app.get('api/v1/activities', handler.Activity())
+        this.http.app.get('api/v1/activities/:id', handler.ActivityByID())
     }
 }
 

--- a/src/internal/media/media.ts
+++ b/src/internal/media/media.ts
@@ -19,7 +19,7 @@ class Media {
 
     private loadHttp(usecase: Usecase) {
         const handler = new Handler(usecase, this.logger)
-        this.http.app.get('/v1/media/', handler.FindAll())
+        this.http.app.get('api/v1/media/', handler.FindAll())
     }
 }
 

--- a/src/internal/news/news.ts
+++ b/src/internal/news/news.ts
@@ -19,7 +19,7 @@ class News {
 
     private loadHttp(usecase: Usecase) {
         const handler = new Handler(usecase, this.logger)
-        this.http.app.get('/v1/news', handler.FindAll())
+        this.http.app.get('api/v1/news', handler.FindAll())
     }
 }
 

--- a/src/internal/prayerTimes/prayerTimes.ts
+++ b/src/internal/prayerTimes/prayerTimes.ts
@@ -19,7 +19,7 @@ class PrayerTime {
 
     private loadHttp(usecase: Usecase) {
         const handler = new Handler(usecase, this.logger)
-        this.http.app.get('/v1/prayer-times/:date', handler.FindByDate())
+        this.http.app.get('api/v1/prayer-times/:date', handler.FindByDate())
     }
 }
 


### PR DESCRIPTION
## Overview

- fix(route): add prefix `/api` for routes

 ## Evidence
- title: fix(route): add prefix API for routes
- project: Digitalisasi Al Jabbar
- participants: @ayocodingit @rhmnmbr 