### PR TITLE
refactor(core): move filters to the repository

### DIFF
--- a/src/internal/core/repository/mongo/repository.ts
+++ b/src/internal/core/repository/mongo/repository.ts
@@ -1,7 +1,9 @@
+import { DateTime } from 'luxon'
 import winston from 'winston'
 import activitySchema from '../../../../database/mongo/schema/activity.schema'
 import bannerSchema from '../../../../database/mongo/schema/banner.schema'
 import { PropPaginate } from '../../../../helpers/paginate'
+import { FindAll } from '../../entity/interface'
 
 class Repository {
     private banner = bannerSchema
@@ -12,11 +14,34 @@ class Repository {
         return this.banner.find()
     }
 
-    public FindAll({ limit, offset }: PropPaginate, filters: Object) {
+    private getFilters(query: FindAll) {
+        let filters = {}
+
+        if (query.is_today) {
+            const today = DateTime.now().toISODate()
+            filters = Object.assign(filters, {
+                date: new Date(today),
+            })
+        } else {
+            filters = Object.assign(filters, {
+                date: {
+                    $gte: new Date(
+                        DateTime.now().plus({ days: 1 }).toISODate()
+                    ),
+                },
+            })
+        }
+
+        return filters
+    }
+
+    public FindAll({ limit, offset }: PropPaginate, query: FindAll) {
+        const filters = this.getFilters(query)
         return this.activity.find(filters).skip(offset).limit(limit)
     }
 
-    public Count(filters: Object) {
+    public Count(query: FindAll) {
+        const filters = this.getFilters(query)
         return this.activity.find(filters).count()
     }
 

--- a/src/internal/core/usecase/usecase.ts
+++ b/src/internal/core/usecase/usecase.ts
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon'
 import winston from 'winston'
 import { Meta, PropPaginate } from '../../../helpers/paginate'
 import error from '../../../pkg/error'
@@ -18,31 +17,9 @@ class Usecase {
         return res
     }
 
-    private getFilters(query: FindAll) {
-        let filters = {}
-
-        if (query.is_today) {
-            const today = DateTime.now().toISODate()
-            filters = Object.assign(filters, {
-                date: new Date(today),
-            })
-        } else {
-            filters = Object.assign(filters, {
-                date: {
-                    $gte: new Date(
-                        DateTime.now().plus({ days: 1 }).toISODate()
-                    ),
-                },
-            })
-        }
-
-        return filters
-    }
-
     public async Activity(prop: PropPaginate, query: FindAll) {
-        const filters = this.getFilters(query)
-        const res = await this.repository.FindAll(prop, filters)
-        const count = await this.repository.Count(filters)
+        const res = await this.repository.FindAll(prop, query)
+        const count = await this.repository.Count(query)
 
         return {
             data: res,


### PR DESCRIPTION
# Overview

- refactor(core): move filters to the repository
- just refactor because it does not rule compliant with principle clean architectures

## Evidence
- title: refactor(core): move filters to the repository
- project: Digitalisasi Al Jabbar
- participants: @ayocodingit @rhmnmbr @samudra-ajri @indraprasetya154 @rachadiannovansyah 