### PR TITLE
fix(prayer-times): add crawling next month

### DIFF
--- a/src/cron/prayerTimes.cron.ts
+++ b/src/cron/prayerTimes.cron.ts
@@ -12,11 +12,18 @@ const prayerTimes = async () => {
 
     const prayerTimes = new PrayerTimes(config, logger)
     const today = DateTime.now()
-    const calendar = await prayerTimes.Calender(today.year, today.month)
+    const nextMonth = today.plus({ months: 1 })
+    const calendars = await prayerTimes.Calender(today.year, today.month)
+    const calendarNextMonth = await prayerTimes.Calender(
+        nextMonth.year,
+        nextMonth.month
+    )
 
-    for (const item of calendar) {
-        const date = ConvertTimestampToISODate(item.date.timestamp)
-        const times = prayerTimes.FormatTimes(item.timings, '+07:00 (WIB)')
+    calendars.push(...calendarNextMonth)
+
+    for (const calendar of calendars) {
+        const date = ConvertTimestampToISODate(calendar.date.timestamp)
+        const times = prayerTimes.FormatTimes(calendar.timings, '+07:00 (WIB)')
 
         await prayerTimesSchema.updateOne(
             {


### PR DESCRIPTION
## Overview

- fix(prayer times): add crawling next month
- why must we make to addition next month? for this case, the day of the end month and then the next day to times fajr is empty because there is not yet an execution to get next month

## Evidence
- title: fix(prayer-times): add crawling next month
- project: Digitalisasi Al Jabbar
- participants: @ayocodingit @rhmnmbr @rachadiannovansyah @imamdev93 